### PR TITLE
Add option to skip tests and fix small warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,28 +10,32 @@ target_sources(circular_buffer INTERFACE $<BUILD_INTERFACE:${detail_header_files
 target_include_directories(circular_buffer INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(circular_buffer SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 
-add_executable(tests_main ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
-target_link_libraries(tests_main circular_buffer)
+option(JM_CIRCULAR_BUFFER_BUILD_TESTS "Build tests for circular buffer" ON)
 
-# catch integration for tests
+if (JM_CIRCULAR_BUFFER_BUILD_TESTS)
+	add_executable(tests_main ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
+	target_link_libraries(tests_main circular_buffer)
 
-set (CATCH_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/Catch/include")
+	# catch integration for tests
 
-include ("${PROJECT_SOURCE_DIR}/Catch/contrib/ParseAndAddCatchTests.cmake")
+	set (CATCH_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/Catch/include")
 
-set (TEST_APP_NAME "circular_buffer_test")
+	include ("${PROJECT_SOURCE_DIR}/Catch/contrib/ParseAndAddCatchTests.cmake")
 
-include_directories (${PROJECT_SOURCE_DIR}/include ${CATCH_INCLUDE_PATH})
+	set (TEST_APP_NAME "circular_buffer_test")
 
-set (TEST_SOURCE_FILES
-		${PROJECT_SOURCE_DIR}/test/main.cpp)
+	include_directories (${PROJECT_SOURCE_DIR}/include ${CATCH_INCLUDE_PATH})
 
-#set target executable
-add_executable (${TEST_APP_NAME} ${TEST_SOURCE_FILES})
+	set (TEST_SOURCE_FILES
+			${PROJECT_SOURCE_DIR}/test/main.cpp)
 
-#add the library
-target_link_libraries (${TEST_APP_NAME} circular_buffer)
+	#set target executable
+	add_executable (${TEST_APP_NAME} ${TEST_SOURCE_FILES})
 
-enable_testing()
+	#add the library
+	target_link_libraries (${TEST_APP_NAME} circular_buffer)
 
-ParseAndAddCatchTests (${TEST_APP_NAME})
+	enable_testing()
+
+	ParseAndAddCatchTests (${TEST_APP_NAME})
+endif()

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -226,7 +226,7 @@ namespace jm {
                 _pos             = other._pos;
                 _left_in_forward = other._left_in_forward;
                 return *this;
-            };
+            }
 
 
             JM_CB_CONSTEXPR reference operator*() const JM_CB_NOEXCEPT


### PR DESCRIPTION
1. I got this warning with gcc (Debian 12.2.0-14) 12.2.0 when compiling with -Wpedantic
`.../circular_buffer.hpp:229: error: extra ‘;’ [-Werror=pedantic]`. Fixed this warning by removing redundant symbol.
2. Add cmake option to skip tests. This is useful when using this library as a cmake subdirectory. I want only use it as an interface and I do not want to clone Catch subrepo that only used for tests. I can do it by explicitly setting JM_CIRCULAR_BUFFER_BUILD_TESTS to OFF before calling add_subdirectory in CMake:
```
set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
set(JM_CIRCULAR_BUFFER_BUILD_TESTS OFF)
add_subdirectory(external/circular_buffer)
```
By default, the behaviour remains same.